### PR TITLE
Task: T0149 - account_id visible for vendor managers

### DIFF
--- a/nsm_account/views/account_invoice_view.xml
+++ b/nsm_account/views/account_invoice_view.xml
@@ -78,7 +78,7 @@
             <field name="arch" type="xml">
                 <data>
 		            <xpath expr="//field[@name='supplier_invoice_number']" position="replace">
-                        <field name="supplier_invoice_number" required="1" groups="account.group_account_invoice"/>
+                        <field name="supplier_invoice_number" required="1" groups="account.group_account_invoice,account_invoice_2step_validation.vendor_manager"/>
                     </xpath>
                 </data>
             </field>

--- a/nsm_account_invoice_2step_validation/views/account_invoice_view.xml
+++ b/nsm_account_invoice_2step_validation/views/account_invoice_view.xml
@@ -11,6 +11,19 @@
             <xpath expr="//field[@name='product_id']" position="attributes">
                 <attribute name="domain">[('purchase_ok','=',True)]</attribute>
             </xpath>
+            <xpath expr="//group/field[@name='account_id']" position="attributes">
+                <attribute name="groups">account.group_account_manager,account_invoice_2step_validation.vendor_manager</attribute>
+            </xpath>
+        </field>
+    </record>
+    <record id="invoice_supplier_form_auth_nsm" model="ir.ui.view">
+        <field name="name">account.invoice</field>
+        <field name="model">account.invoice</field>
+        <field name="inherit_id" ref="account_invoice_2step_validation.invoice_supplier_form_auth"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='account_id']" position="attributes">
+                <attribute name="groups">account.group_account_user,account_invoice_2step_validation.vendor_manager,account.group_account_invoice,account_invoice_2step_validation.goedk_facturen</attribute>
+            </xpath>
         </field>
     </record>
 </odoo>

--- a/nsm_supplier_portal/views/menu_view.xml
+++ b/nsm_supplier_portal/views/menu_view.xml
@@ -55,19 +55,19 @@
 
         
         <menuitem name="Finance" id="account.menu_finance"
-            groups="account.group_account_user,account.group_account_manager,account.group_account_invoice,account_invoice_2step_validation.goedk_facturen"
+            groups="account.group_account_user,account.group_account_manager,account.group_account_invoice,account_invoice_2step_validation.goedk_facturen,account_invoice_2step_validation.vendor_manager"
             sequence="50"/>
 
 	<menuitem id="account.menu_finance_payables"
 	    name="Suppliers" parent="account.menu_finance"
-	    groups="account.group_account_invoice,account_invoice_2step_validation.goedk_facturen"
+	    groups="account.group_account_invoice,account_invoice_2step_validation.goedk_facturen,account_invoice_2step_validation.vendor_manager"
             sequence="3"/>
             
         <menuitem id="menu_action_invoice_tree_supportal"
             action="action_invoice_tree_supportal"
 	        name="Vendor Bills"
             parent="account.menu_finance_payables"
-            groups="account_invoice_2step_validation.goedk_facturen"
+            groups="account_invoice_2step_validation.goedk_facturen,account_invoice_2step_validation.vendor_manager"
             sequence="3"/>
 
     <!-- Submited Invoice Menu Item -->


### PR DESCRIPTION
Modules: nsm_account, nsm_account_invoice_2step_validation, nsm_supplier_portal.
This commit includes followings.
Updates the following fields to be visible for the group Vendor Manager
- account.invoice.supplier_invoice_number
- account.invoice.account_id
- account.invoice.line.account_id
Updates the following menus to be visible for the group Vendor Manager
- Finance (main menu)
- Suppliers (parent menu)
- Vendor Bills (child menu)
Note: The access control is yet updated in the code for the object account.invoice with the group Vendor Manager.